### PR TITLE
fix: fix issue with paint tool not working with default color

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,7 +170,7 @@ let colorSelected = COLOR_PICKER.value;
 const saveColorToLocalStorage = () => {
   localStorage.setItem('colorSelected', JSON.stringify(colorSelected));
 };
-
+saveColorToLocalStorage()
 // Load the previously selected color from local storage when the page is reloaded
 const loadColorToLocalStorage = () => {
   const localStorageColor = JSON.parse(localStorage.getItem('colorSelected'));


### PR DESCRIPTION
Fixed a bug where the paint tool was not working with the default color when using the app for the first time. The issue was caused by an error in the JavaScript code. Specifically, the saveColorToLocalStorage function wasn't being called, so the default color wasn't being saved to the color picker.